### PR TITLE
fix: ページタイトルを修正

### DIFF
--- a/src/redirect/index.php
+++ b/src/redirect/index.php
@@ -10,7 +10,7 @@ $csrfToken = generateCsrfToken();
 <html lang="ja">
 <head>
     <meta charset="UTF-8"/>
-    <title>PAY.JP サブウィンドウ型3Dセキュア実装サンプル</title>
+    <title>PAY.JP リダイレクト型3Dセキュア実装サンプル</title>
 </head>
 <body>
 


### PR DESCRIPTION
## 概要

リダイレクト型の Checkout 埋め込みページのタイトルが誤っている。