### PR TITLE
Checkoutをプレリリースから現行版へ変更

### DIFF
--- a/src/redirect/index.php
+++ b/src/redirect/index.php
@@ -5,6 +5,11 @@ require_once __DIR__ . '/../libs/csrfToken.php';
 
 session_start();
 $csrfToken = generateCsrfToken();
+$apiKey = $_ENV['PAYJP_PUBLIC_KEY'];
+if (!$apiKey) {
+    echo 'PAYJP_PUBLIC_KEY環境変数がセットされていません。README.mdを参照し、pk_から始まる公開鍵をセットしてください。';
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -32,7 +37,7 @@ $csrfToken = generateCsrfToken();
                     type="text/javascript"
                     src="https://checkout.pay.jp"
                     class="payjp-button"
-                    data-payjp-key="<?php echo htmlspecialchars($_ENV['PAYJP_PUBLIC_KEY'] ?? ''); // `pk_` から始まる公開鍵を設定してください。 ?>"
+                    data-payjp-key="<?php echo htmlspecialchars($apiKey); ?>"
                     data-payjp-three-d-secure="true"
                     data-payjp-three-d-secure-workflow="redirect"
                     data-payjp-extra-attribute-email

--- a/src/redirect/index.php
+++ b/src/redirect/index.php
@@ -30,7 +30,7 @@ $csrfToken = generateCsrfToken();
         <div>
             <script
                     type="text/javascript"
-                    src="https://checkout.pay.jp/prerelease"
+                    src="https://checkout.pay.jp"
                     class="payjp-button"
                     data-payjp-key="<?php echo htmlspecialchars($_ENV['PAYJP_PUBLIC_KEY'] ?? ''); // `pk_` から始まる公開鍵を設定してください。 ?>"
                     data-payjp-three-d-secure="true"

--- a/src/sub-window/index.php
+++ b/src/sub-window/index.php
@@ -5,6 +5,11 @@ require_once __DIR__ . '/../libs/csrfToken.php';
 
 session_start();
 $csrfToken = generateCsrfToken();
+$apiKey = $_ENV['PAYJP_PUBLIC_KEY'];
+if (!$apiKey) {
+    echo 'PAYJP_PUBLIC_KEY環境変数がセットされていません。README.mdを参照し、pk_から始まる公開鍵をセットしてください。';
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -32,7 +37,7 @@ $csrfToken = generateCsrfToken();
                 type="text/javascript"
                 src="https://checkout.pay.jp"
                 class="payjp-button"
-                data-payjp-key="<?php echo htmlspecialchars($_ENV['PAYJP_PUBLIC_KEY'] ?? ''); // `pk_` から始まる公開鍵を設定してください。 ?>"
+                data-payjp-key="<?php echo htmlspecialchars($apiKey); ?>"
                 data-payjp-three-d-secure="true"
                 data-payjp-three-d-secure-workflow="subwindow"
                 data-payjp-extra-attribute-email

--- a/src/sub-window/index.php
+++ b/src/sub-window/index.php
@@ -30,7 +30,7 @@ $csrfToken = generateCsrfToken();
         <div>
             <script
                 type="text/javascript"
-                src="https://checkout.pay.jp/prerelease"
+                src="https://checkout.pay.jp"
                 class="payjp-button"
                 data-payjp-key="<?php echo htmlspecialchars($_ENV['PAYJP_PUBLIC_KEY'] ?? ''); // `pk_` から始まる公開鍵を設定してください。 ?>"
                 data-payjp-three-d-secure="true"


### PR DESCRIPTION
- Checkout現行版がアップデート（プレリリース機能と同等に更新）されたので、 `https://checkout.pay.jp/prerelease` としている箇所を変更
- ついでに、APIキーがセットされている時の挙動が分かりづらいのでエラーを表示
![スクリーンショット 2025-03-06 16 37 12](https://github.com/user-attachments/assets/f053bcf3-7977-40d2-96a5-0c71a480818c)
