### PR TITLE
feat: 支払い時3Dセキュア（iframe型）サンプルを追加

### DIFF
--- a/src/charge-tds/iframe/create-charge.php
+++ b/src/charge-tds/iframe/create-charge.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../libs/csrfToken.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Method not allowed.']);
+    exit;
+}
+
+session_start();
+
+try {
+    verifyCsrfToken();
+
+    $payjpToken = $_POST['payjp-token'] ?? '';
+    if ($payjpToken === '') {
+        throw new RuntimeException('トークンが取得できませんでした。');
+    }
+
+    Payjp\Payjp::$apiKey = $_ENV['PAYJP_SECRET_KEY'] ?? '';
+
+    $charge = Payjp\Charge::create([
+        'card' => $payjpToken,
+        'amount' => 100,
+        'currency' => 'jpy',
+        'three_d_secure' => true,
+    ]);
+
+    echo json_encode([
+        'charge_id' => $charge->id,
+        'three_d_secure_status' => $charge->three_d_secure_status ?? null,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'message' => $e->getMessage(),
+    ]);
+}

--- a/src/charge-tds/iframe/create-charge.php
+++ b/src/charge-tds/iframe/create-charge.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * 支払い時3Dセキュア - 支払い作成エンドポイント
+ *
+ * フロントエンドから送信されたトークンを使って支払いを作成します。
+ * three_d_secure: true を指定することで、3Dセキュア認証が必要な支払いを作成します。
+ */
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -17,13 +23,18 @@ session_start();
 try {
     verifyCsrfToken();
 
+    // フロントエンドで作成したトークンを取得します。
     $payjpToken = $_POST['payjp-token'] ?? '';
     if ($payjpToken === '') {
         throw new RuntimeException('トークンが取得できませんでした。');
     }
 
+    // `PAYJP_SECRET_KEY` には `sk_` から始まる秘密鍵を設定してください。
     Payjp\Payjp::$apiKey = $_ENV['PAYJP_SECRET_KEY'] ?? '';
 
+    // 支払いを作成します。
+    // three_d_secure: true を指定すると、3Dセキュア認証が必要な状態で支払いが作成されます。
+    // この時点では支払いは「保留」状態であり、まだ決済は完了していません。
     $charge = Payjp\Charge::create([
         'card' => $payjpToken,
         'amount' => 100,
@@ -31,6 +42,8 @@ try {
         'three_d_secure' => true,
     ]);
 
+    // 支払いIDをフロントエンドに返します。
+    // フロントエンドではこのIDを使って openThreeDSecureIframe() を呼び出します。
     echo json_encode([
         'charge_id' => $charge->id,
         'three_d_secure_status' => $charge->three_d_secure_status ?? null,

--- a/src/charge-tds/iframe/finish-charge.php
+++ b/src/charge-tds/iframe/finish-charge.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../libs/csrfToken.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['message' => 'Method not allowed.']);
+    exit;
+}
+
+session_start();
+
+try {
+    verifyCsrfToken();
+
+    $chargeId = $_POST['charge_id'] ?? '';
+    if ($chargeId === '') {
+        throw new RuntimeException('支払いIDが取得できませんでした。');
+    }
+
+    Payjp\Payjp::$apiKey = $_ENV['PAYJP_SECRET_KEY'] ?? '';
+
+    $charge = Payjp\Charge::retrieve($chargeId);
+    $threeDSecureStatus = $charge->three_d_secure_status ?? '';
+
+    if ($threeDSecureStatus === 'attempted' || $threeDSecureStatus === 'verified') {
+        $charge = $charge->tdsFinish();
+
+        echo json_encode([
+            'charge_id' => $charge->id,
+            'amount' => $charge->amount,
+            'three_d_secure_status' => $charge->three_d_secure_status ?? null,
+        ]);
+        exit;
+    }
+
+    $tdsError = $_POST['tds_error'] ?? '';
+    $message = '3Dセキュアが完了していないため支払いを確定できません。';
+    if ($tdsError !== '') {
+        $message .= ' (' . $tdsError . ')';
+    }
+
+    http_response_code(400);
+    echo json_encode([
+        'message' => $message,
+        'three_d_secure_status' => $threeDSecureStatus,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'message' => $e->getMessage(),
+    ]);
+}

--- a/src/charge-tds/iframe/index.php
+++ b/src/charge-tds/iframe/index.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../libs/csrfToken.php';
+
+session_start();
+$csrfToken = generateCsrfToken();
+$apiKey = $_ENV['PAYJP_PUBLIC_KEY'];
+if (!$apiKey) {
+    echo 'PAYJP_PUBLIC_KEY環境変数がセットされていません。README.mdを参照し、pk_から始まる公開鍵をセットしてください。';
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8"/>
+    <title>PAY.JP 支払い時3Dセキュア実装サンプル（iframe型）</title>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+        .form-row {
+            margin-bottom: 1rem;
+        }
+        #card-element {
+            padding: 12px;
+            border: 1px solid #cbd5e1;
+            border-radius: 4px;
+            max-width: 420px;
+        }
+        #card-errors {
+            color: #b91c1c;
+            margin-top: 0.5rem;
+        }
+        #result {
+            margin-top: 1.5rem;
+        }
+        .note {
+            color: #475569;
+        }
+        .status {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+<h1>支払い時の3Dセキュア（iframe型）</h1>
+<p class="note">トークン作成時ではなく、支払い作成後に3Dセキュア認証を行うサンプルです。</p>
+
+<form id="payment-form">
+    <div class="form-row">
+        <label>
+            カード名義
+            <input type="text" name="cardholder_name" placeholder="TARO YAMADA" autocomplete="cc-name" />
+        </label>
+    </div>
+    <div class="form-row">
+        <label>
+            メールアドレス
+            <input type="email" name="email" placeholder="sample@example.com" autocomplete="email" />
+        </label>
+    </div>
+    <div class="form-row">
+        <label>
+            電話番号
+            <input type="tel" name="phone" placeholder="09012345678" autocomplete="tel" />
+            <small style="color: #64748b;">※ 日本の番号は自動でE.164形式に変換されます</small>
+        </label>
+    </div>
+    <div class="form-row">
+        <p>おにぎり 100円</p>
+        <div id="card-element"></div>
+        <div id="card-errors" role="alert"></div>
+    </div>
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>" />
+    <button id="submit-button" type="submit">支払いを開始</button>
+</form>
+
+<div id="result"></div>
+
+<br />
+<a href="/">戻る</a>
+
+<script src="https://js.pay.jp/v2/pay.js"></script>
+<script type="text/javascript">
+    const payjp = Payjp("<?php echo htmlspecialchars($apiKey); ?>");
+    const elements = payjp.elements();
+    const cardElement = elements.create('card');
+    cardElement.mount('#card-element');
+
+    const form = document.getElementById('payment-form');
+    const submitButton = document.getElementById('submit-button');
+    const cardErrors = document.getElementById('card-errors');
+    const result = document.getElementById('result');
+
+    function setBusy(isBusy) {
+        submitButton.disabled = isBusy;
+        submitButton.textContent = isBusy ? '処理中...' : '支払いを開始';
+    }
+
+    function showResult(html) {
+        result.innerHTML = html;
+    }
+
+    function clearMessages() {
+        cardErrors.textContent = '';
+        showResult('');
+    }
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        clearMessages();
+        setBusy(true);
+
+        const formData = new FormData(form);
+        const name = formData.get('cardholder_name');
+        const email = formData.get('email');
+        let phone = formData.get('phone');
+
+        // 日本の電話番号をE.164形式に変換（例: 09012345678 → +819012345678）
+        if (phone && phone.startsWith('0')) {
+            phone = '+81' + phone.slice(1);
+        }
+
+        if (!email && !phone) {
+            cardErrors.textContent = 'メールアドレスか電話番号のどちらかを入力してください。';
+            setBusy(false);
+            return;
+        }
+
+        try {
+            const tokenResponse = await payjp.createToken(cardElement, {
+                card: {
+                    name: name || undefined,
+                    email: email || undefined,
+                    phone: phone || undefined,
+                },
+            });
+
+            if (tokenResponse.error) {
+                throw new Error(tokenResponse.error.message || 'トークン作成に失敗しました。');
+            }
+
+            const createParams = new URLSearchParams();
+            createParams.append('payjp-token', tokenResponse.id);
+            createParams.append('csrf_token', formData.get('csrf_token'));
+
+            const createResponse = await fetch('/charge-tds/iframe/create-charge.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: createParams.toString(),
+            });
+
+            const createJson = await createResponse.json();
+            if (!createResponse.ok) {
+                throw new Error(createJson.message || '支払い作成に失敗しました。');
+            }
+
+            const chargeId = createJson.charge_id;
+            let tdsErrorText = '';
+
+            try {
+                await payjp.openThreeDSecureIframe(chargeId);
+            } catch (error) {
+                tdsErrorText = error && error.message ? error.message : String(error);
+            }
+
+            const finishParams = new URLSearchParams();
+            finishParams.append('charge_id', chargeId);
+            finishParams.append('csrf_token', formData.get('csrf_token'));
+            if (tdsErrorText) {
+                finishParams.append('tds_error', tdsErrorText);
+            }
+
+            const finishResponse = await fetch('/charge-tds/iframe/finish-charge.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: finishParams.toString(),
+            });
+
+            const finishJson = await finishResponse.json();
+            if (!finishResponse.ok) {
+                throw new Error(finishJson.message || '支払い確定に失敗しました。');
+            }
+
+            showResult(
+                '<p class="status">支払いが完了しました。</p>' +
+                '<p>Charge ID: ' + finishJson.charge_id + '</p>' +
+                '<p>金額: ' + finishJson.amount + '</p>'
+            );
+        } catch (error) {
+            cardErrors.textContent = error && error.message ? error.message : '処理中にエラーが発生しました。';
+        } finally {
+            setBusy(false);
+        }
+    });
+</script>
+</body>
+</html>

--- a/src/charge-tds/iframe/index.php
+++ b/src/charge-tds/iframe/index.php
@@ -17,30 +17,39 @@ if (!$apiKey) {
     <meta charset="UTF-8"/>
     <title>PAY.JP 支払い時3Dセキュア実装サンプル（iframe型）</title>
     <style>
-        body {
-            font-family: sans-serif;
-        }
         .form-row {
             margin-bottom: 1rem;
         }
-        #card-element {
-            padding: 12px;
-            border: 1px solid #cbd5e1;
+        .form-row label {
+            display: block;
+            margin-bottom: 0.25rem;
+        }
+        .form-row input {
+            padding: 8px;
+            border: 1px solid #ccc;
             border-radius: 4px;
-            max-width: 420px;
+            width: 300px;
+        }
+        .form-row small {
+            display: block;
+            color: #666;
+        }
+        #card-element {
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            max-width: 300px;
         }
         #card-errors {
-            color: #b91c1c;
+            color: red;
             margin-top: 0.5rem;
         }
         #result {
-            margin-top: 1.5rem;
-        }
-        .note {
-            color: #475569;
+            margin-top: 1rem;
         }
         .status {
             font-weight: bold;
+            color: green;
         }
     </style>
 </head>
@@ -49,29 +58,23 @@ if (!$apiKey) {
 <p class="note">トークン作成時ではなく、支払い作成後に3Dセキュア認証を行うサンプルです。</p>
 
 <form id="payment-form">
+    <p>おにぎり 100円</p>
     <div class="form-row">
-        <label>
-            カード名義
-            <input type="text" name="cardholder_name" placeholder="TARO YAMADA" autocomplete="cc-name" />
-        </label>
-    </div>
-    <div class="form-row">
-        <label>
-            メールアドレス
-            <input type="email" name="email" placeholder="sample@example.com" autocomplete="email" />
-        </label>
-    </div>
-    <div class="form-row">
-        <label>
-            電話番号
-            <input type="tel" name="phone" placeholder="09012345678" autocomplete="tel" />
-            <small style="color: #64748b;">※ 日本の番号は自動でE.164形式に変換されます</small>
-        </label>
-    </div>
-    <div class="form-row">
-        <p>おにぎり 100円</p>
         <div id="card-element"></div>
         <div id="card-errors" role="alert"></div>
+    </div>
+    <div class="form-row">
+        <label>カード名義</label>
+        <input type="text" name="cardholder_name" placeholder="TARO YAMADA" autocomplete="cc-name" />
+    </div>
+    <div class="form-row">
+        <label>メールアドレス</label>
+        <input type="email" name="email" placeholder="sample@example.com" autocomplete="email" />
+    </div>
+    <div class="form-row">
+        <label>電話番号</label>
+        <input type="tel" name="phone" placeholder="09012345678" autocomplete="tel" />
+        <small>※ 日本の番号は自動でE.164形式に変換されます</small>
     </div>
     <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>" />
     <button id="submit-button" type="submit">支払いを開始</button>

--- a/src/index.html
+++ b/src/index.html
@@ -12,5 +12,9 @@
     <li><a href="/redirect">リダイレクト型実装例</a></li>
     <li><a href="/customer-card-tds/redirect">顧客カードに対する3Dセキュア（リダイレクト型実装例）</a></li>
 </ul>
+<h2>支払い時の3Dセキュア</h2>
+<ul>
+    <li><a href="/charge-tds/iframe">iframe型実装例</a></li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- 支払い時3Dセキュア（iframe型）のサンプルを追加
- トークン作成後に `three_d_secure: true` で支払いを作成し、`openThreeDSecureIframe()` で3DS認証を行うフロー
- 日本の電話番号をE.164形式に自動変換

## 追加ファイル
- `src/charge-tds/iframe/index.php` - フロントエンド（カードフォーム、3DS iframe表示）
- `src/charge-tds/iframe/create-charge.php` - 支払い作成API
- `src/charge-tds/iframe/finish-charge.php` - 3DS完了後の支払い確定

## Test plan
- [x] ローカルで動作確認
- [x] テストカードで3DS認証フローを確認
- [x] email/phoneバリデーションの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)